### PR TITLE
Add requests requirement and make to_dict more robust

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ nose==1.3.3
 pylint==1.2.1
 python-dateutil==2.2
 python-mimeparse==0.1.4
+requests==2.3.0
 six==1.6.1
 sphinxcontrib-httpdomain==1.2.1
 unittest2==0.5.1

--- a/server/app/models.py
+++ b/server/app/models.py
@@ -44,7 +44,8 @@ class Base(ndb.Model):
 
     def to_dict(self):
         result = super(Base, self).to_dict()
-        result['key'] = self.key.id() #get the key as a string
+        if self.key:
+            result['key'] = self.key.id() # Add the key as a string
         return result
 
 class Submission(Base): #pylint: disable=R0903


### PR DESCRIPTION
Tests were failing for me because of the new to_dict assuming that every entity has a key.  In particular, see trace below. Perhaps the deeper problem is that the test infrastructure doesn't create valid entities.
# 

```
ERROR: test_entity_create_basic (test_api.AssignmentAPITest)
Tests creating an empty entity.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/denero/Documents/workspace/ok/server/tests/test_api.py", line 185, in test_entity_create_basic
    self.post_entity(self.inst)
  File "/Users/denero/Documents/workspace/ok/server/tests/test_api.py", line 100, in post_entity
    self.post_json('/{}/new'.format(self.name), data=inst, *args, **kwds)
  File "/Users/denero/Documents/workspace/ok/server/tests/test_api.py", line 89, in post_json
    data = data.to_dict()
  File "/Users/denero/Documents/workspace/ok/server/app/models.py", line 47, in to_dict
    result['key'] = self.key.id() #get the key as a string
AttributeError: 'NoneType' object has no attribute 'id'
```
