### PR TITLE
Changed models to KeyProperty from StructuredProperty. Fixed tests.

### DIFF
--- a/server/app/api.py
+++ b/server/app/api.py
@@ -118,8 +118,8 @@ class SubmitNDBImplementation:
 
     def create_submission(self, user, assignment, messages):
         """Create submission using user as parent to ensure ordering."""
-        submission =  models.Submission(submitter=user,
-                                        assignment=assignment,
+        submission =  models.Submission(submitter=user.key,
+                                        assignment=assignment.key,
                                         messages=messages)
         submission.put()
         return submission
@@ -154,6 +154,8 @@ class SubmissionAPI(MethodView, APIResource):
 
     @handle_error
     def post(self, user=None):
+        if 'submitter' in request.json:
+            del request.json['submitter']
         for key in request.json:
             if key not in self.post_fields:
                 return create_api_response(400, 'Unknown field %s' % key)
@@ -184,12 +186,12 @@ class SubmissionAPI(MethodView, APIResource):
             return create_api_response(400, "user for submission doesn't exist")
         return create_api_response(200, "", obj)
 
-    def index(self, user):
+    def index(self, user=None):
         """
         Index HTTP method thing.
         """
         return create_api_response(
-            200, "success", list(self.get_model().query(self.get_model().submitter.email == user.email)))
+            200, "success", list(self.get_model().query(self.get_model().submitter == user.key)))
 
 def register_api(view, endpoint, url, primary_key='key', pk_type='int', admin=False):
     """

--- a/server/app/models.py
+++ b/server/app/models.py
@@ -78,7 +78,7 @@ class Assignment(Base):
     name = ndb.StringProperty() # Must be unique to support submission.
     # TODO(denero) Validate uniqueness of name.
     points = ndb.FloatProperty()
-    creator = ndb.StructuredProperty(User)
+    creator = ndb.KeyProperty(User)
 
 
 class Course(Base):
@@ -86,7 +86,7 @@ class Course(Base):
     institution = ndb.StringProperty() # E.g., 'UC Berkeley'
     name = ndb.StringProperty() # E.g., 'CS 61A'
     offering = ndb.StringProperty()  # E.g., 'Fall 2014'
-    assignments = ndb.StructuredProperty(Assignment, repeated=True)
+    assignments = ndb.KeyProperty(Assignment, repeated=True)
     due_dates = ndb.DateTimeProperty(repeated=True)
     creator = ndb.StructuredProperty(User)
 
@@ -110,8 +110,8 @@ def validate_messages(_, messages):
 
 class Submission(Base):
     """A submission is generated each time a student runs the client."""
-    submitter = ndb.StructuredProperty(User)
-    assignment = ndb.StructuredProperty(Assignment)
+    submitter = ndb.KeyProperty(User)
+    assignment = ndb.KeyProperty(Assignment)
     messages = ndb.StringProperty(validator=validate_messages)
     created = ndb.DateTimeProperty(auto_now_add=True)
 


### PR DESCRIPTION
So it turns out that StructureProperties aren't actually stored in the database....

It's not an actual reference to another entity. Look at [this](https://developers.google.com/appengine/docs/python/ndb/properties#structured), and in particular the paragraph below the code.

I switched the code to use `KeyProperty` instead of `StructuredProperty`. We can still access the referenced entities using `submission.submitter.get()`, for example. 
