### PR TITLE
update hooks to compile on commit

### DIFF
--- a/hooks/compile
+++ b/hooks/compile
@@ -1,0 +1,4 @@
+#!/bin/sh
+cd client
+./publish.py
+cd ..

--- a/hooks/pre-commit-run.py
+++ b/hooks/pre-commit-run.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+import sys
+
+USE_PYLINT = True
+
+try:
+    from git_pylint_commit_hook import commit_hook
+except ImportError:
+    USE_PYLINT = False
+
+def main():
+    if USE_PYLINT:
+        result = commit_hook.check_repo(9, "pylint", ".pylintrc", "-r y")
+        if not result:
+            sys.exit(1)
+
+if __name__ == '__main__':
+    main()
+    sys.exit(0)

--- a/hooks/pre-commit.py
+++ b/hooks/pre-commit.py
@@ -1,19 +1,3 @@
-#!/usr/bin/env python
-import sys
-
-USE_PYLINT = True
-
-try:
-    from git_pylint_commit_hook import commit_hook
-except ImportError:
-    USE_PYLINT = False
-
-def main():
-    if USE_PYLINT:
-        result = commit_hook.check_repo(9, "pylint", ".pylintrc", "-r y")
-        if not result:
-            sys.exit(1)
-
-if __name__ == '__main__':
-    main()
-    sys.exit(0)
+#!/bin/sh
+$GIT_DIR/../hooks/pre-commit-run.py
+$GIT_DIR/../hooks/compile


### PR DESCRIPTION
The reason this is so hacky is so it'll seamlessly integrate with people's existing ok repos without them having to re symlink their hooks.
