### PR TITLE
forces https

### DIFF
--- a/server/app.yaml
+++ b/server/app.yaml
@@ -37,7 +37,9 @@ handlers:
   script: lib.gae_mini_profiler.main.app
 
 - url: /static
+  secure: always
   static_dir: static
 
 - url: .*
   script: run.app.app
+  secure: always


### PR DESCRIPTION
I believe that this change forces people to visit the site with HTTPS, not HTTP according to [here](https://developers.google.com/appengine/docs/python/config/appconfig?csw=1).

I wasn't able to get it working on localhost due to SSL errors, so we might have to push to prod to test.
