### PR TITLE
Graceful error messages for the OK client 

### DIFF
--- a/client/__main__.py
+++ b/client/__main__.py
@@ -1,15 +1,12 @@
 import sys
 sys.path.append('.')
 
-# List of unsupported in (Major, Minor, Micro) form. 
+# TODO: List of unsupported in (Major, Minor, Micro) form. 
 # unsupported_versions = [(1,2,2)]
 
 # Basic Version Checking
 if sys.version_info[0] < 3:
 	sys.exit("ok requires Python 3. \nFor more info: http://www-inst.eecs.berkeley.edu/~cs61a/fa14/lab/lab01/#installing-python")
-
-# TODO: List of unsupported in (Major, Minor, Micro) form. 
-# unsupported_versions = [(1,2,2)]
 
 def main():
 	import ok

--- a/client/ok.py
+++ b/client/ok.py
@@ -185,7 +185,7 @@ def ok_main(args):
                 # print("Nothing was sent to the server!")
                 pass
             except TypeError:
-                print("Uh-oh! OK could not authenticate you. Running OK locally")
+                print("Uh-oh! ok could not authenticate you. Running ok locally.")
                 args.local = True
 
         for proto in protocols:


### PR DESCRIPTION
See #184 for details. 
The basic concept is to display graceful error messages for when we know ok is going to crash. 

```
$ python ok
ok requires Python 3.
For more info: http://www-inst.eecs.berkeley.edu/~cs61a/fa14/lab/lab01/#installing-python
``
```
