### PR TITLE
Use new versioning api in client

### DIFF
--- a/client/cli/ok.py
+++ b/client/cli/ok.py
@@ -72,8 +72,7 @@ def send_to_server(access_token, messages, name, server,
         try:
             #response_json = json.loads(response)
             if ex.code == 403:
-                response_json = json.loads(ex.read().decode())
-                get_latest_version(response_json['current_download_link'])
+                get_latest_version(server)
             #message = response_json['message']
             #indented = '\n'.join('\t' + line for line in message.split('\n'))
             #print(indented)
@@ -87,10 +86,13 @@ def send_to_server(access_token, messages, name, server,
 # Software Updating #
 #####################
 
-def get_latest_version(address):
+def get_latest_version(server):
     """Check for the latest version of ok and update this file accordingly.
     """
     #print("We detected that you are running an old version of ok.py: {0}".format(VERSION))
+
+    # Get server version
+    address = "https://" + server + "/api/v1" + "/version/ok/download"
 
     try:
         #print("Updating now...")


### PR DESCRIPTION
The new updating scheme does the following:
1. Sends a request to `/api/v1/version/ok`
2. Gets back JSON. One of the fields is `'current_version'`. Use this to check if the client version is not equal to the current_version.
3. If not equal, use the `current_download_link` to grab the zip (most likely from Github Releases). Write the binary to `'ok'` as before.

@moowiz @Some3141 Can you take a look? The endpoint isn't working yet so I haven't been able to test it.

Resolves #206 
