### PR TITLE
Add partner scoring to ok client

### DIFF
--- a/client/models/core.py
+++ b/client/models/core.py
@@ -64,6 +64,8 @@ class Assignment(serialize.Serializable):
 class Test(serialize.Serializable):
     """Represents all suites for a single test in an assignment."""
 
+    DEFAULT_PARTNER = ''
+
     REQUIRED = {
         'names': serialize.SerializeArray(serialize.STR),
         'points': serialize.FLOAT,
@@ -74,6 +76,7 @@ class Test(serialize.Serializable):
         'hidden_params': serialize.DICT,    # Hidden from students.
         'note': serialize.STR,
         'extra': serialize.BOOL_FALSE,
+        'partner': serialize.SerializePrimitive(DEFAULT_PARTNER, str),
     }
 
     def __init__(self, **fields):

--- a/client/tests/protocols/scoring_test.py
+++ b/client/tests/protocols/scoring_test.py
@@ -14,24 +14,37 @@ class DisplayBreakdownTest(unittest.TestCase):
         self.assertEqual(expect, scoring.display_breakdown(scores_as_dict))
 
     def testNoScores(self):
-        self.display(0, [])
+        self.display({}, [])
 
     def testFullPoints(self):
-        self.display(5, [
-            ('q1', (2, 2)),
-            ('q2', (3, 3)),
+        self.display({core.Test.DEFAULT_PARTNER: 5}, [
+            (('q1', core.Test.DEFAULT_PARTNER), (2, 2)),
+            (('q2', core.Test.DEFAULT_PARTNER), (3, 3)),
         ])
 
     def testPartialPoints(self):
-        self.display(2, [
-            ('q1', (1, 2)),
-            ('q2', (1, 9)),
+        self.display({core.Test.DEFAULT_PARTNER: 2}, [
+            (('q1', core.Test.DEFAULT_PARTNER), (1, 2)),
+            (('q2', core.Test.DEFAULT_PARTNER), (1, 9)),
         ])
 
     def testZeroPoints(self):
-        self.display(0, [
-            ('q1', (0, 2)),
-            ('q2', (0, 9)),
+        self.display({core.Test.DEFAULT_PARTNER: 0}, [
+            (('q1', core.Test.DEFAULT_PARTNER), (0, 2)),
+            (('q2', core.Test.DEFAULT_PARTNER), (0, 9)),
+        ])
+
+    def testPartnerPoints_noDefault(self):
+        self.display({'A': 2, 'B': 7}, [
+            (('q1', 'A'), (2, 2)),
+            (('q2', 'B'), (7, 9)),
+        ])
+
+    def testPartnerPoints_default(self):
+        self.display({core.Test.DEFAULT_PARTNER: 3, 'A': 2, 'B': 4}, [
+            (('q1', 'A'), (2, 2)),
+            (('q2', 'B'), (4, 9)),
+            (('q3', core.Test.DEFAULT_PARTNER), (3, 3)),
         ])
 
 class ScoreTest(unittest.TestCase):


### PR DESCRIPTION
Staff can specify Tests that are specific to a particular partner by adding a 'partner' field to the tests:

```
test = {
    ...
    'partner': 'A',
    ...
}
```

The partner string can be any arbitrary string -- it is up to the staff to be consistent. If the 'partner' field is omitted, the test will apply to all partners. The actual field will be assigned a value of `core.Test.DEFAULT_PARTNER`, which is assigned to the empty string (but can be changed).

Here is an example of the point breakdown:

```
Partner A score:
24.0
Partner B score:
24.0
```
