### PR TITLE
Create custom docker image for worker

### DIFF
--- a/Dockerfile-worker
+++ b/Dockerfile-worker
@@ -1,0 +1,3 @@
+FROM cs61a/ok-server
+
+CMD ["./manage.py", "worker"]

--- a/Dockerfile-worker
+++ b/Dockerfile-worker
@@ -1,3 +1,3 @@
 FROM cs61a/ok-server
 
-CMD ["./manage.py", "worker"]
+CMD ["./worker.py"]

--- a/Makefile
+++ b/Makefile
@@ -36,3 +36,6 @@ docker-test:
 docker-build:
 	find . | grep -E "(__pycache__|\.pyc|\.DS_Store|\.db|\.pyo$\)" | xargs rm -rf
 	docker build -t cs61a/ok-server .
+
+docker-build-worker: docker-build
+	docker build -t cs61a/ok-worker -f Dockerfile-worker .

--- a/azure/paas/azure.deploy.json
+++ b/azure/paas/azure.deploy.json
@@ -44,20 +44,36 @@
         "description": "Optional Docker registry password"
       }
     },
-    "dockerImageName": {
+    "serverImageName": {
       "minLength": 1,
       "defaultValue": "cs61a/ok-server",
       "type": "string",
       "metadata": {
-        "description": "Ok.py Docker image"
+        "description": "Ok.py server Docker image"
       }
     },
-    "dockerImageTag": {
+    "serverImageTag": {
       "minLength": 1,
       "defaultValue": "latest",
       "type": "string",
       "metadata": {
-        "description": "Ok.py Docker image Tag"
+        "description": "Ok.py server Docker image tag"
+      }
+    },
+    "workerImageName": {
+      "minLength": 1,
+      "defaultValue": "cs61a/ok-worker",
+      "type": "string",
+      "metadata": {
+        "description": "Ok.py worker Docker image"
+      }
+    },
+    "workerImageTag": {
+      "minLength": 1,
+      "defaultValue": "latest",
+      "type": "string",
+      "metadata": {
+        "description": "Ok.py worker Docker image tag"
       }
     },
     "azureAdAppID": {
@@ -221,10 +237,10 @@
             "value": "[parameters('dockerRegistryUrl')]"
           },
           "dockerImageName": {
-            "value": "[parameters('dockerImageName')]"
+            "value": "[parameters('serverImageName')]"
           },
           "dockerImageTag": {
-            "value": "[parameters('dockerImageTag')]"
+            "value": "[parameters('serverImageTag')]"
           },
           "mysqlUsername": {
             "value": "[parameters('mySqlUsername')]"
@@ -263,10 +279,10 @@
             "value": "[parameters('dockerRegistryPassword')]"
           },
           "dockerImageName": {
-            "value": "[parameters('dockerImageName')]"
+            "value": "[parameters('serverImageName')]"
           },
           "dockerImageTag": {
-            "value": "[parameters('dockerImageTag')]"
+            "value": "[parameters('serverImageTag')]"
           },
           "mysqlUsername": {
             "value": "[parameters('mySqlUsername')]"
@@ -357,10 +373,10 @@
             "value": "[parameters('dockerRegistryPassword')]"
           },
           "dockerImageName": {
-            "value": "[parameters('dockerImageName')]"
+            "value": "[parameters('serverImageName')]"
           },
           "dockerImageTag": {
-            "value": "[parameters('dockerImageTag')]"
+            "value": "[parameters('serverImageTag')]"
           },
           "mysqlUsername": {
             "value": "[parameters('mySqlUsername')]"
@@ -439,13 +455,10 @@
             "value": "[parameters('dockerRegistryPassword')]"
           },
           "dockerImageName": {
-            "value": "[parameters('dockerImageName')]"
+            "value": "[parameters('workerImageName')]"
           },
           "dockerImageTag": {
-            "value": "[parameters('dockerImageTag')]"
-          },
-          "dockerStartupCommand": {
-            "value": "./manage.py worker"
+            "value": "[parameters('workerImageTag')]"
           },
           "mysqlUsername": {
             "value": "[parameters('mySqlUsername')]"
@@ -467,6 +480,15 @@
           },
           "applicationInsightsKey": {
             "value": "[reference('AppInsights').outputs.AppInsights.value.InstrumentationKey]"
+          },
+          "azureAdAppID": {
+            "value": "[parameters('azureAdAppId')]"
+          },
+          "azureAdAppSecret": {
+            "value": "[parameters('azureAdAppSecret')]"
+          },
+          "azureAdTenantID": {
+            "value": "[parameters('azureAdTenantID')]"
           },
           "SecretKey": {
             "value": "[variables('secretKey')]"

--- a/azure/paas/azure.deploy.json
+++ b/azure/paas/azure.deploy.json
@@ -76,6 +76,13 @@
         "description": "Ok.py worker Docker image tag"
       }
     },
+    "autograderUrl": {
+      "minLength": 1,
+      "type": "string",
+      "metadata": {
+        "description": "URL to autograder deployment"
+      }
+    },
     "azureAdAppID": {
       "defaultValue": "",
       "type": "string",
@@ -408,6 +415,9 @@
           "azureAdTenantID": {
             "value": "[parameters('azureAdTenantID')]"
           },
+          "autograderUrl": {
+            "value": "[parameters('autograderUrl')]"
+          },
           "SecretKey": {
             "value": "[variables('secretKey')]"
           }
@@ -489,6 +499,9 @@
           },
           "azureAdTenantID": {
             "value": "[parameters('azureAdTenantID')]"
+          },
+          "autograderUrl": {
+            "value": "[parameters('autograderUrl')]"
           },
           "SecretKey": {
             "value": "[variables('secretKey')]"

--- a/azure/paas/webapp.deploy.json
+++ b/azure/paas/webapp.deploy.json
@@ -41,10 +41,6 @@
     "dockerImageTag": {
       "type": "string"
     },
-    "dockerStartupCommand": {
-      "defaultValue": "",
-      "type": "string"
-    },
     "storageAccountName": {
       "type": "string"
     },
@@ -171,7 +167,6 @@
             "DOCKER_REGISTRY_SERVER_USERNAME": "[parameters('dockerRegistryUsername')]",
             "DOCKER_REGISTRY_SERVER_PASSWORD": "[parameters('dockerRegistryPassword')]",
             "DOCKER_CUSTOM_IMAGE_NAME": "[concat(parameters('dockerRegistryUrl'),'/',parameters('dockerImageName'),':',parameters('dockerImageTag'))]",
-            "DOCKER_CUSTOM_IMAGE_RUN_COMMAND": "[parameters('dockerStartupCommand')]",
             "WEBSITES_ENABLE_APP_SERVICE_STORAGE": "false",
             "DATABASE_URL": "[concat('mysql://',parameters('mySqlUsername'),'%40',parameters('mySQLServerName'),':',parameters('mysqlPassword'),'@',parameters('mySQLServerName'),'.mysql.database.azure.com:3306/ok?')]",
             "DB_ROW_FORMAT": "default",

--- a/azure/paas/webapp.deploy.json
+++ b/azure/paas/webapp.deploy.json
@@ -102,6 +102,13 @@
         "description": "Application Insights Key"
       }
     },
+    "autograderUrl": {
+      "minLength": 1,
+      "type": "string",
+      "metadata": {
+        "description": "URL to autograder deployment"
+      }
+    },
     "SecretKey": {
       "type": "securestring",
       "metadata": {
@@ -183,6 +190,7 @@
             "MICROSOFT_APP_SECRET": "[parameters('azureAdAppSecret')]",
             "MICROSOFT_APP_ID": "[parameters('azureAdAppId')]",
             "MICROSOFT_TENANT_ID": "[parameters('azureAdTenantId')]",
+            "AUTOGRADER_URL": "[parameters('autograderUrl')]",
             "SECRET_KEY": "[parameters('SecretKey')]"
           }
         },


### PR DESCRIPTION
AppService for Containers seems to have an issue with the custom run
command for the Docker image. According to the logs, the worker's
AppService was starting an instance of the OK server instead of the
worker. As a simple work-around, this change introduces a Dockerfile for
the OK worker which bakes the correct CMD into the image. This does
create some level of redundancy, but on the bright side it also means
that in the future we could publish a more optimized image for the
worker, e.g. excluding the frontend assets, etc.

Also: pass-through auto-grader URL in ARM template