### PR TITLE
Change badge URLs to new github organization `okpy`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Logo](https://raw.githubusercontent.com/Cal-CS-61A-Staff/ok/master/server/static/img/logo-tiny.png)](#)
+[![Logo](https://raw.githubusercontent.com/okpy/ok/master/server/static/img/logo-tiny.png)](#)
 =====
 
 The ok.py server collects submissions and displays analysis of student progress
@@ -8,8 +8,8 @@ Courses can sign up for our free hosted service on [okpy.org](https://okpy.org)
 
 The ok.py software was developed for CS 61A at UC Berkeley.
 
-[![Build Status](https://circleci.com/gh/Cal-CS-61A-Staff/ok.svg?style=shield)](https://circleci.com/gh/Cal-CS-61A-Staff/ok)
-[![Coverage Status](https://coveralls.io/repos/github/Cal-CS-61A-Staff/ok/badge.svg)](https://coveralls.io/github/Cal-CS-61A-Staff/ok)
+[![Build Status](https://circleci.com/gh/okpy/ok.svg?style=shield)](https://circleci.com/gh/Cal-CS-61A-Staff/ok)
+[![Coverage Status](https://coveralls.io/repos/github/okpy/ok/badge.svg)](https://coveralls.io/github/Cal-CS-61A-Staff/ok)
 [![Docker Repository on Quay](https://quay.io/repository/cs61a/ok-server/status "Docker Repository on Quay")](https://quay.io/repository/cs61a/ok-server)
 
 View Documentation at [OK Documentation](https://okpy.github.io/documentation)


### PR DESCRIPTION
Updates badges from old GitHub organization `Cal-61a-Staff` to `okpy`

Signed-off-by: Colin Schoen <cschoen@berkeley.edu>