### PR TITLE
Update remaining URLs in README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ See `documentation/CONTRIBUTING.md`
 
 Recent activity:
 
-[![Throughput Graph](https://graphs.waffle.io/Cal-CS-61A-Staff/ok/throughput.svg)](https://waffle.io/Cal-CS-61A-Staff/ok/metrics/throughput)
+[![Throughput Graph](https://graphs.waffle.io/okpy/ok/throughput.svg)](https://waffle.io/okpy/ok/metrics/throughput)
 
 Deploying
 ---------
@@ -104,8 +104,8 @@ Refer to [The Elements of Python Style](https://github.com/amontalenti/elements-
 Some useful things for developers to know:
 
 1. Testing with ok-client
-   - To test with ok-client, please follow the instructions for the ok-client repo [here](https://github.com/Cal-CS-61A-Staff/ok-client).
+   - To test with ok-client, please follow the instructions for the ok-client repo [here](https://github.com/okpy/ok-client).
    - Once you are inside the virtual environment for ok-client, you can make a new binary by using the command `ok-publish`.
    - Start the local ok server.
    - When running the ok binary, add the flags `--insecure --server localhost:<port>` to point it to the running ok-server
-   - To find demo assignments that you can use the binary with, look in [ok-client/demo](https://github.com/Cal-CS-61A-Staff/ok-client/tree/master/demo)
+   - To find demo assignments that you can use the binary with, look in [ok-client/demo](https://github.com/okpy/ok-client/tree/master/demo)


### PR DESCRIPTION
This updates the remaining URLs in README.md to point to the new
okpy github organization.

Signed-off-by: Colin Schoen <cschoen@berkeley.edu>