### PR TITLE
 Fix unbound local variable error in section console

### DIFF
--- a/server/controllers/admin.py
+++ b/server/controllers/admin.py
@@ -483,14 +483,16 @@ def section_console(cid, sctn_id=None):
                                Enrollment.section == sctn_id,
                                Enrollment.course == current_course)
                        .all())
-        student_emails = []
-        for enrollment in enrollments:
-            student_emails.append(EMAIL_FORMAT.format(
-                name=enrollment.user.identifier,
-                email=enrollment.user.email))
-        student_emails_str = "\n".join(student_emails)
     else:
-        students, emails = [], []
+        enrollments = []
+
+    student_emails = []
+    for enrollment in enrollments:
+        student_emails.append(EMAIL_FORMAT.format(
+            name=enrollment.user.identifier,
+            email=enrollment.user.email))
+
+    student_emails_str = "\n".join(student_emails)
 
     return render_template(
         'staff/course/section/section.html',

--- a/server/controllers/admin.py
+++ b/server/controllers/admin.py
@@ -446,7 +446,7 @@ def section_console(cid, sctn_id=None):
     courses, current_course = get_courses(cid)
     form = forms.SectionAssignmentForm()
     if form.validate_on_submit():
-        email, role , section = form.email.data, form.role.data, form.section.data
+        email, role, section = form.email.data, form.role.data, form.section.data
         user = User.lookup(email)
         if user:
             record = Enrollment.query.filter_by(user_id=user.id,
@@ -458,40 +458,44 @@ def section_console(cid, sctn_id=None):
                 form.role.data = record.role
                 Enrollment.enroll_from_form(cid, form)
                 flash("Changed {email} to Section {section}".format(
-                email=email, section=section), "success")
+                    email=email, section=section), "success")
         else:
             flash("{email} is not enrolled as a {role}".format(
                 email=email, role=role), "error")
 
     if sctn_id is None:
-        staff_record = (Enrollment.query.filter_by(user_id=current_user.id, course_id=cid)
-                                       .filter(Enrollment.role.in_(STAFF_ROLES))
-                                       .one_or_none())
+        staff_record = (Enrollment.query
+                        .filter_by(user_id=current_user.id, course_id=cid)
+                        .filter(Enrollment.role.in_(STAFF_ROLES))
+                        .one_or_none())
         # Admins may not have any staff record, but can view enrollment
         # for all courses.
         sctn_id = staff_record.section if staff_record else None
 
     staff = (Enrollment.query
-                          .filter(Enrollment.role.in_(STAFF_ROLES),
-                                  Enrollment.course == current_course)
-                          .all())
+             .filter(Enrollment.role.in_(STAFF_ROLES),
+                     Enrollment.course == current_course)
+             .all())
 
     if sctn_id is not None:
         enrollments = (Enrollment.query
-                              .filter(Enrollment.role.in_([STUDENT_ROLE]),
-                                      Enrollment.section == sctn_id,
-                                      Enrollment.course == current_course)
-                              .all())
+                       .filter(Enrollment.role.in_([STUDENT_ROLE]),
+                               Enrollment.section == sctn_id,
+                               Enrollment.course == current_course)
+                       .all())
         student_emails = []
         for enrollment in enrollments:
-            student_emails.append(EMAIL_FORMAT.format(name=enrollment.user.identifier,
-                                email=enrollment.user.email))
+            student_emails.append(EMAIL_FORMAT.format(
+                name=enrollment.user.identifier,
+                email=enrollment.user.email))
         student_emails_str = "\n".join(student_emails)
     else:
         students, emails = [], []
-    return render_template('staff/course/section/section.html',
-                       courses=courses, form=form, current_course=current_course,
-                       enrollments=enrollments, staff=staff, emails=student_emails_str)
+
+    return render_template(
+        'staff/course/section/section.html',
+        courses=courses, form=form, current_course=current_course,
+        enrollments=enrollments, staff=staff, emails=student_emails_str)
 
 @admin.route("/course/<int:cid>/assignments")
 @is_staff(course_arg='cid')


### PR DESCRIPTION
Issue found by @taupalosaurus 

Full stacktrace:

```
[2018-07-03 16:54:18,984] ERROR in app: Exception on /admin/course/1/section/ [GET]
Traceback (most recent call last):
  File "/usr/local/lib/python3.5/site-packages/flask/app.py", line 1982, in wsgi_app
    response = self.full_dispatch_request()
  File "/usr/local/lib/python3.5/site-packages/flask/app.py", line 1614, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/usr/local/lib/python3.5/site-packages/flask_restful/__init__.py", line 271, in error_router
    return original_handler(e)
  File "/usr/local/lib/python3.5/site-packages/flask/app.py", line 1518, in handle_user_exception
    return handler(e)
  File "/usr/local/lib/python3.5/site-packages/applicationinsights/flask/ext.py", line 167, in exception_handler
    raise exception
  File "/usr/local/lib/python3.5/site-packages/flask/app.py", line 1612, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/local/lib/python3.5/site-packages/flask/app.py", line 1598, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/usr/local/lib/python3.5/site-packages/flask_login/utils.py", line 228, in decorated_view
    return func(*args, **kwargs)
  File "/code/server/controllers/admin.py", line 56, in wrapper
    return func(*args, **kwargs)
  File "/code/server/controllers/admin.py", line 494, in section_console
    enrollments=enrollments, staff=staff, emails=student_emails_str)
UnboundLocalError: local variable 'enrollments' referenced before assignment
```

In order to make the fix easier, I first did some refactoring/cleanup in 380d88f. The actual fix is in 2d102b.