### PR TITLE
Fix links to jobs when hosted at non-root URL

### DIFF
--- a/server/constants.py
+++ b/server/constants.py
@@ -34,6 +34,8 @@ GRADES_BUCKET = 'ok_grades_bucket'
 TIMEZONE = 'America/Los_Angeles'
 ISO_DATETIME_FMT = '%Y-%m-%d %H:%M:%S'
 
+APPLICATION_ROOT = os.getenv('APPLICATION_ROOT', '/')
+
 AUTOGRADER_URL = os.getenv('AUTOGRADER_URL', 'https://autograder.cs61a.org')
 
 SENDGRID_USERNAME = os.getenv("SENDGRID_USERNAME")

--- a/server/settings/_base.py
+++ b/server/settings/_base.py
@@ -3,6 +3,8 @@
 """
 import os
 
+from server import constants
+
 # Shared settings across all environments
 
 def initialize_config(cls):
@@ -27,7 +29,7 @@ class Config(object):
 
     APPINSIGHTS_INSTRUMENTATIONKEY = os.getenv('APPINSIGHTS_INSTRUMENTATIONKEY')
 
-    APPLICATION_ROOT = os.getenv('APPLICATION_ROOT', '/')
+    APPLICATION_ROOT = constants.APPLICATION_ROOT
 
     # Service Keys
     GOOGLE = dict(


### PR DESCRIPTION
@taupalosaurus found this issue on the jobs page where the links to the job results assumed that the application is always hosted at the root.

This change fixes the links to the job results by pre-pending the APPLICATION_ROOT to the link result URL if it's not already there. Performing this fix in the background job decorator as a post-processing step means that all the existing background job code which uses links as return values doesn't have to change.

Screenshot of issue (blue) and fix (red):

![image](https://user-images.githubusercontent.com/1086421/42236688-93f2376a-7ec9-11e8-9257-d114feec43df.png)
