### PR TITLE
Changes all instances of Cal-CS-61A-Staff -> okpy

### DIFF
--- a/documentation/api.md
+++ b/documentation/api.md
@@ -9,7 +9,7 @@ The Ok Server API provides a variety of endpoints to interact with the Ok Server
 ## Authentication
 
 Ok uses access tokens to allow access to the API. To obtain a token for a specific account, use the ok-client
-to login with your Google account. Download the latest version of ok from the [GitHub Releases](https://github.com/Cal-CS-61A-Staff/ok-client/releases/) or from [cs61a.org/ok](http://cs61a.org/ok)
+to login with your Google account. Download the latest version of ok from the [GitHub Releases](https://github.com/okpy/ok-client/releases/) or from [cs61a.org/ok](http://cs61a.org/ok)
 
 Then run the following command
 `python3 ok --get-token`
@@ -70,7 +70,7 @@ curl "https://okpy.org/api/v3/"
     "code": 200,
     "message": "success",
     "data": {
-        "github": "https://github.com/Cal-CS-61A-Staff/ok",
+        "github": "https://github.com/okpy/ok",
         "url": "/api/v3/",
         "version": "v3",
         "documentation": "https://okpy.github.io/documentation"
@@ -99,7 +99,7 @@ curl "https://okpy.org/api/v3/version"
         "results": [
             {
                 "name": "ok-client",
-                "download_link": "https://github.com/Cal-CS-61A-Staff/ok-client/releases/download/v1.6.14/ok",
+                "download_link": "https://github.com/okpy/ok-client/releases/download/v1.6.14/ok",
                 "current_version": "v1.6.14"
             }
         ]

--- a/documentation/oauth.md
+++ b/documentation/oauth.md
@@ -10,7 +10,7 @@ For more information about OAuth2, refer to these documents: [OAuth2 Simplified]
 
 [Demo of OK OAuth >](https://ok-oauth.app.cs61a.org)
 
-> [Demo Source Code >](https://github.com/Cal-CS-61A-Staff/ok/blob/master/documentation/sample_oauth.py)
+> [Demo Source Code >](https://github.com/okpy/ok/blob/master/documentation/sample_oauth.py)
 
 ## Registering an OAuth Client
 >> <h3>Demo App Redirect URIs</h3>
@@ -64,8 +64,8 @@ Parameter | URL
 
 ## Sample OK OAuth Client
 
-A functional OAuth Login implementation is provided [in the OK repo](https://github.com/Cal-CS-61A-Staff/ok/blob/master/documentation/sample_oauth.py).
-> [Example App Source Code >](https://github.com/Cal-CS-61A-Staff/ok/blob/master/documentation/sample_oauth.py)
+A functional OAuth Login implementation is provided [in the OK repo](https://github.com/okpy/ok/blob/master/documentation/sample_oauth.py).
+> [Example App Source Code >](https://github.com/okpy/ok/blob/master/documentation/sample_oauth.py)
 
 If you are using Python & Flask OAuthLib an example config is provided here.
 

--- a/documentation/ok.md
+++ b/documentation/ok.md
@@ -8,5 +8,5 @@ Contact us to use our hosted service (http://okpy.org) for your course.
 
 The ok.py software was developed for CS 61A at UC Berkeley.
 
-[![Build Status](https://travis-ci.org/Cal-CS-61A-Staff/ok.svg)](https://travis-ci.org/Cal-CS-61A-Staff/ok)
-[![Coverage Status](https://coveralls.io/repos/github/Cal-CS-61A-Staff/ok/badge.svg?branch=master)](https://coveralls.io/github/Cal-CS-61A-Staff/ok?branch=master)
+[![Build Status](https://travis-ci.org/okpy/ok.svg)](https://travis-ci.org/okpy/ok)
+[![Coverage Status](https://coveralls.io/repos/github/okpy/ok/badge.svg?branch=master)](https://coveralls.io/github/okpy/ok?branch=master)

--- a/documentation/v3-design-models.md
+++ b/documentation/v3-design-models.md
@@ -10,7 +10,7 @@ See `models.py` for the most recent version of these models. This is intended as
   - Still leaning towards having the FS table - but not presenting it as a "Concept" to users. Users will just see a checkmark ✅ next to their submission.
 
 - Groups:
-  -  We have a list of constraints for groups on the [Wiki](https://github.com/Cal-CS-61A-Staff/ok/wiki/Group-&-Submission-Consistency)
+  -  We have a list of constraints for groups on the [Wiki](https://github.com/okpy/ok/wiki/Group-&-Submission-Consistency)
   -  What if we associate submissions & backups with groups?
     -   Makes it easier to get submissions (though not by much)
     -   Handling group transitions while maintaining the full list of constraints above will be hard.
@@ -232,7 +232,7 @@ class Group(db.Model, TimestampMixin):
     Members of a group can view each other's submissions.
 
     Specification:
-    https://github.com/Cal-CS-61A-Staff/ok/wiki/Group-&-Submission-Consistency
+    https://github.com/okpy/ok/wiki/Group-&-Submission-Consistency
     """
     id = db.Column(db.Integer(), primary_key=True)
     assignment = db.Column(db.ForeignKey("assignment.id"), nullable=False)

--- a/manage.py
+++ b/manage.py
@@ -69,7 +69,7 @@ def setup_default():
     )
     db.session.add(course)
 
-    url = 'https://github.com/Cal-CS-61A-Staff/ok-client/releases/download/v1.5.5/ok'
+    url = 'https://github.com/okpy/ok-client/releases/download/v1.5.5/ok'
     ok = Version(name='ok-client', current_version='v1.5.4', download_link=url)
     db.session.add(ok)
     db.session.commit()

--- a/server/controllers/about.py
+++ b/server/controllers/about.py
@@ -13,7 +13,7 @@ def documentation():
 
 @about.route('/github/')
 def github():
-    return redirect('https://github.com/Cal-CS-61A-Staff/ok')
+    return redirect('https://github.com/okpy/ok')
 
 @about.route('/publications/')
 def research():

--- a/server/controllers/api.py
+++ b/server/controllers/api.py
@@ -506,7 +506,7 @@ class V3Info(PublicResource):
             'version': API_VERSION,
             'url': '/api/{0}/'.format(API_VERSION),
             'documentation': 'https://okpy.github.io/documentation',
-            'github': 'https://github.com/Cal-CS-61A-Staff/ok'
+            'github': 'https://github.com/okpy/ok'
         }
 
 

--- a/server/generate.py
+++ b/server/generate.py
@@ -321,7 +321,7 @@ def seed_backups():
 
 def seed_versions():
     print('Seeding version...')
-    url = 'https://github.com/Cal-CS-61A-Staff/ok-client0/releases/download/v1.5.5/ok'
+    url = 'https://github.com/okpy/ok-client0/releases/download/v1.5.5/ok'
     ok = Version(name='ok-client', current_version='v1.5.5', download_link=url)
     db.session.add(ok)
 

--- a/server/templates/footer.html
+++ b/server/templates/footer.html
@@ -17,7 +17,7 @@
       <div class="col-xs-12 col-sm-3">
         <ul class="nav nav-pills nav-justified">
           <li>
-            <a href="https://github.com/Cal-CS-61A-Staff/ok">GitHub Repo</a>
+            <a href="https://github.com/okpy/ok">GitHub Repo</a>
           </li>
         </ul>
       </div>

--- a/server/templates/index.html
+++ b/server/templates/index.html
@@ -123,7 +123,7 @@
     </div>
     <div class="col-md-6">
         <h2>Open Source</h2>
-        <p> The source code for OK is available on <a href="https://github.com/Cal-CS-61A-Staff/ok">GitHub</a>. You can run an instance of OK on your own servers. </p>
+        <p> The source code for OK is available on <a href="https://github.com/okpy/ok">GitHub</a>. You can run an instance of OK on your own servers. </p>
     </div>
 </div>
 

--- a/server/templates/staff/client_version.html
+++ b/server/templates/staff/client_version.html
@@ -36,7 +36,7 @@
               {% call forms.render_form(form, action_url="", action_text='Update Client Version',
                                           class_='form') %}
                   {{ forms.render_field(form.current_version, label_visible=true, placeholder='v1.5.4', type='text') }}
-                  {{ forms.render_field(form.download_link, label_visible=true, placeholder='https://github.com/Cal-CS-61A-Staff/ok-client/releases/download/v1.5.4/ok', type='text') }}
+                  {{ forms.render_field(form.download_link, label_visible=true, placeholder='https://github.com/okpy/ok-client/releases/download/v1.5.4/ok', type='text') }}
               {% endcall %}
           </div>
           <!-- /.box-body -->

--- a/server/templates/staff/course/course.html
+++ b/server/templates/staff/course/course.html
@@ -150,7 +150,7 @@
                     </a>
                   </li>
                   <li>
-                    <a href="https://github.com/Cal-CS-61A-Staff/ok/issues">
+                    <a href="https://github.com/okpy/ok/issues">
                       <i class="fa fa-github"></i>
                       GitHub Issues
                     </a>

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -96,7 +96,7 @@ class TestApi(OkTestCase):
             'version': 'v3',
             'url': '/api/v3/',
             'documentation': 'https://okpy.github.io/documentation',
-            'github': 'https://github.com/Cal-CS-61A-Staff/ok'
+            'github': 'https://github.com/okpy/ok'
         }
         assert response.json['message'] == 'success'
         assert response.json['code'] == 200

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -26,7 +26,7 @@ class TestVersion(OkTestCase):
 
         data = {
             "current_version": "v1.6.0",
-            "download_link": "https://github.com/Cal-CS-61A-Staff/ok-client/releases/download/v1.5.4/ok"
+            "download_link": "https://github.com/okpy/ok-client/releases/download/v1.5.4/ok"
         }
 
         response = self.client.post('/admin/versions/ok-client',
@@ -56,7 +56,7 @@ class TestVersion(OkTestCase):
 
         data = {
             "current_version": "v1.6.0",
-            "download_link": "https://github.com/Cal-CS-61A-Staff/ok-client/releases/download/v1.5.4/ok"
+            "download_link": "https://github.com/okpy/ok-client/releases/download/v1.5.4/ok"
         }
 
         response = self.client.post('/admin/versions/ok-client', data=data)

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -594,7 +594,7 @@ if driver:
 
 
         # Commented out because this job occasionally times out on CI.
-        # https://github.com/Cal-CS-61A-Staff/ok/issues/1113
+        # https://github.com/okpy/ok/issues/1113
         # def test_job(self):
         #     self._login_as(self.staff1.email)
 


### PR DESCRIPTION
The repo was moved from the `Cal-CS-61A-Staff` github organization to
the `okpy` github organization. This updates all instances of the
old github organization to the new one.

Signed-off-by: Colin Schoen <cschoen@berkeley.edu>