### PR TITLE
Enable autopy-server to replicate across nodes

### DIFF
--- a/azure/paas/README.md
+++ b/azure/paas/README.md
@@ -6,7 +6,7 @@ These templates and scripts deploy [Ok.py](www.okpy.org) to Azure. In a producti
 
 The provided templates deploy everything within the Resource Group outlined below. Items outside the resource group are an indication as to how Ok.py can integrate with additional Azure services:
 
-![Azure PaaS Architecture](https://user-images.githubusercontent.com/1086421/42100204-91251e74-7b8d-11e8-8a89-88e917047270.png)
+![Azure PaaS Architecture](https://user-images.githubusercontent.com/1086421/43547159-75306220-95a8-11e8-8059-58c355fc32d0.png)
 
 ## Setup
 

--- a/azure/paas/helm/templates/autopy-server.yaml
+++ b/azure/paas/helm/templates/autopy-server.yaml
@@ -71,33 +71,16 @@ spec:
         - name: AUTOPY_URL
           value: https://{{.Values.letsencryptDomain}}/autopy
         - name: FILES_ROOT
-          value: /files
+          value: agfiles
+        - name: AZURE_STORAGE_CONNECTION_STRING
+          valueFrom:
+            secretKeyRef:
+              name: storage
+              key: STORAGE_CONNECTION_STRING
         - name: AUTOPY_LOG_LEVEL
           value: {{.Values.logLevel}}
         resources: {}
-        volumeMounts:
-          - mountPath: /files
-            name: autopy-server-files
-      volumes:
-      - name: autopy-server-files
-        persistentVolumeClaim:
-          claimName: autopy-server-files
       restartPolicy: Always
-status: {}
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  creationTimestamp: null
-  labels:
-    service: autopy-server-files
-  name: autopy-server-files
-spec:
-  accessModes:
-  - ReadWriteOnce
-  resources:
-    requests:
-      storage: {{.Values.autopyStorageSize}}
 status: {}
 ---
 apiVersion: v1

--- a/azure/paas/helm/values.yaml
+++ b/azure/paas/helm/values.yaml
@@ -3,7 +3,6 @@
 dockerTag: latest
 dockerRegistry: changeme
 okEnv: prod
-autopyStorageSize: 1Gi
 logLevel: INFO
 
 # tls settings

--- a/azure/paas/setup-storage.sh
+++ b/azure/paas/setup-storage.sh
@@ -29,10 +29,12 @@ az group deployment create \
 #
 
 storage_key="$(jq -r '.properties.outputs.storageKey.value' "${deployment_log}")"
+storage_connection_string="DefaultEndpointsProtocol=https;AccountName=${storage_name};AccountKey=${storage_key};EndpointSuffix=core.windows.net"
 
 cat > ./secrets/storage.env << EOF
 STORAGE_ACCOUNT_NAME=${storage_name}
 STORAGE_ACCOUNT_KEY=${storage_key}
+STORAGE_CONNECTION_STRING=${storage_connection_string}
 EOF
 
 log "Done with ${storage_name}"


### PR DESCRIPTION
Currently the autopy-server stores the autograder files on the local
file-system via flask-admin. In Kubernetes, the file-system is managed
via a persistent volume claim. However, the volume can only attach to a
single node which means that all autopy-server pods have to be scheduled
to the same node which limits fault tolerance and scalability.

This change switches the autopy-server to use the new direct Azure Blob
Storage integration for flask-admin which stores the autograder files in
a non-local storage. As such, we can remove the persistent volume claim
and autopy-server pods can now be scheduled to arbitrary nodes.

This issue was found by @tmbgreaves.