### PR TITLE
PR has been merged can now use upstream webassets

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,8 +25,7 @@ WTForms>=2.0,<3.0
 # Flask Extensions
 Flask-Assets>=0.12,<0.12.99
 
-# Branch that contains a Unicode bug fix - use until https://github.com/miracle2k/webassets/pull/482 is published
-https://github.com/okpy/webassets/archive/978b8063ce80c7f91c6bf080872dafe4eecf2454.zip
+webassets==0.12.1
 
 Flask-Caching>=1.1
 Flask-Login==0.4.0


### PR DESCRIPTION
webassets has merged the PR in question https://github.com/miracle2k/webassets/pull/482.

We can now go back to using the pypi version of this package.