### PR TITLE
Fix course list link

### DIFF
--- a/server/templates/staff/course/course.edit.html
+++ b/server/templates/staff/course/course.edit.html
@@ -10,7 +10,7 @@
         <small>{{ current_course.offering }}</small>
       </h1>
       <ol class="breadcrumb">
-        <li><a href="url_for('.list_courses')"><i class="fa fa-list"></i> Courses </a></li>
+        <li><a href="{{ url_for('.list_courses') }}"><i class="fa fa-list"></i> Courses </a></li>
         <li><a href="{{ url_for("admin.course", cid=current_course.id) }}">
             <i class="fa fa-university"></i> {{ current_course.offering }}
         </a></li>

--- a/server/templates/staff/course/course.new.html
+++ b/server/templates/staff/course/course.new.html
@@ -9,7 +9,7 @@
         Create Course
       </h1>
       <ol class="breadcrumb">
-        <li><a href="url_for('.list_courses')"><i class="fa fa-list"></i> Courses </a></li>
+        <li><a href="{{ url_for('.list_courses') }}"><i class="fa fa-list"></i> Courses </a></li>
         <li class="active"><a href="#"><i class="fa fa-plus"></i> Create Course</a></li>
       </ol>
   </section>


### PR DESCRIPTION
This fixes a typo that doesn't escape the course list link. Here's what the link used to do:

<img width="317" alt="screenshot 2018-12-08 22 59 35" src="https://user-images.githubusercontent.com/5891442/49694331-4096c680-fb3d-11e8-8452-c7628c790530.png">
<img width="529" alt="screenshot 2018-12-08 22 59 45" src="https://user-images.githubusercontent.com/5891442/49694332-42f92080-fb3d-11e8-823c-9e3b1a011dbc.png">
