### PR TITLE
Add form in Student View for editing enrollment information

### DIFF
--- a/server/controllers/admin.py
+++ b/server/controllers/admin.py
@@ -1448,10 +1448,10 @@ def student_view(cid, email):
         else:
             email, role = form.email.data, form.role.data
             Enrollment.enroll_from_form(cid, form)
-            flash("Edited User Successfully", 'success')
+            flash('Edited User Successfully', 'success')
     else:
         if form.is_submitted():
-            flash("There is an issue with your request.", 'error')
+            flash('There is an issue with your request.', 'error')
 
     courses, current_course = get_courses(cid)
     assignments = current_course.assignments

--- a/server/controllers/admin.py
+++ b/server/controllers/admin.py
@@ -1437,9 +1437,22 @@ def client(client_id):
 # Student View #
 ################
 
-@admin.route("/course/<int:cid>/<string:email>")
+@admin.route("/course/<int:cid>/<string:email>", methods=['GET', 'POST'])
 @is_staff(course_arg='cid')
 def student_view(cid, email):
+
+    form = forms.EnrollmentForm()
+    if form.validate_on_submit():
+        if form.email.data != email:
+            flash("You cannot change the user's email.", 'error')
+        else:
+            email, role = form.email.data, form.role.data
+            Enrollment.enroll_from_form(cid, form)
+            flash("Edited User Successfully", 'success')
+    else:
+        if form.is_submitted():
+            flash("There is an issue with your request.", 'error')
+
     courses, current_course = get_courses(cid)
     assignments = current_course.assignments
 
@@ -1466,7 +1479,7 @@ def student_view(cid, email):
     return render_template('staff/student/overview.html',
                            courses=courses, current_course=current_course,
                            student=student, enrollment=enrollment,
-                           assignments=assignments, moss_results=moss_results)
+                           assignments=assignments, moss_results=moss_results, form=form)
 
 @admin.route("/course/<int:cid>/<string:email>/<int:aid>/timeline")
 @is_staff(course_arg='cid')

--- a/server/templates/staff/student/overview.html
+++ b/server/templates/staff/student/overview.html
@@ -1,5 +1,6 @@
 {% extends "staff/base.html" %}
 {% import "_globalhelpers.html" as helpers %}
+{% import 'staff/_formhelpers.html' as forms %}
 
 {% block title %} {{ student.identifier }} - {{ current_course.display_name_with_semester }}{% endblock %}
 
@@ -96,6 +97,34 @@
           {% endwith %}
         </div>
       </div>
+
+      <!-- Box -->
+      <div class="box">
+        <div class="box-header with-border">
+            <h3 class="box-title">Edit Participant</h3>
+            <div class="box-tools pull-right">
+                <button type="button" class="btn btn-box-tool" data-widget="collapse" data-toggle="tooltip" title="Collapse">
+                    <i class="fa fa-minus"></i>
+                </button>
+            </div>
+        </div>
+        <div class="box-body">
+            <!-- form goes here -->
+            {% call forms.render_form(form, action_url=url_for('.student_view', cid=current_course.id, email=student.email), action_text='Submit',
+            class_='form') %}
+                {{ forms.render_field(form.name, label_visible=true, placeholder='Name', required="required", type='text', value=(student.name or "")) }}
+                {{ forms.render_field(form.email, label_visible=true, required="required", value=student.email, readonly="readonly") }}
+                {{ forms.render_field(form.sid, label_visible=true, placeholder='1234567', type='text', value=(enrollment.sid or "")) }}
+                {{ forms.render_field(form.secondary, label_visible=true, placeholder='cs61a-abc', type='text', value=(enrollment.class_account or "")) }}
+                {{ forms.render_field(form.section, label_visible=true, placeholder='', type='text', value=(enrollment.section or "")) }}
+                {{ forms.render_field(form.role, label_visible=true) }}
+            {% endcall %}
+        </div>
+        <!-- /.box-body -->
+        <!-- /.box-footer-->
+    </div>
+    <!-- /.box -->
+
   </section>
 
   <!-- </body> do not close body in template-->


### PR DESCRIPTION
This resolves issue #1274.

I've added a form to the student view that allows admin/staff to edit information about students like their name, SID, secondary auth, section, and role. Users cannot, however, change students' email addresses since much of the back-end code relies on using the email as an identifier. Maybe this could be a feature in the future. 

<img width="1552" alt="screen shot 2019-01-16 at 12 30 51 am" src="https://user-images.githubusercontent.com/6360587/51228670-6a56c080-1927-11e9-802e-23cc8a931a1c.png">

<img width="1552" alt="screen shot 2019-01-16 at 12 30 55 am" src="https://user-images.githubusercontent.com/6360587/51228694-7f335400-1927-11e9-8911-da38132043dd.png">

<img width="1552" alt="screen shot 2019-01-16 at 12 31 37 am" src="https://user-images.githubusercontent.com/6360587/51228700-85293500-1927-11e9-8be8-da642eb1c949.png">

<img width="1552" alt="screen shot 2019-01-16 at 12 31 45 am" src="https://user-images.githubusercontent.com/6360587/51228704-88242580-1927-11e9-9828-9b6ead8c18ec.png">
