### PR TITLE
Modify edit student form to allow email editing

### DIFF
--- a/server/controllers/admin.py
+++ b/server/controllers/admin.py
@@ -1445,7 +1445,7 @@ def student_view(cid, email):
     form = forms.EnrollmentForm()
     if form.validate_on_submit():
         if form.email.data != email:         
-            #Temporarily override the form's email data to update enrollment
+            #Temporarily override the form's email data to update enrollment first
             new_email = form.email.data
             form.email.data = email
             Enrollment.enroll_from_form(cid, form)

--- a/server/controllers/admin.py
+++ b/server/controllers/admin.py
@@ -1450,7 +1450,7 @@ def student_view(cid, email):
 
             try:
                 if len(user.enrollments(roles=STAFF_ROLES)) > 0 or user.is_admin:
-                    raise Forbidden("Modifying course staff or administrator emails is not permitted")
+                    raise Forbidden("Modifying a course staff or administrator's email is not permitted")
                 user.update_email(new_email)
                 flash('Edited User Successfully', 'success')
             except SQLAlchemyError:

--- a/server/controllers/admin.py
+++ b/server/controllers/admin.py
@@ -1333,7 +1333,7 @@ def unenrollment(cid, user_id):
         flash("Unknown user", "warning")
 
     return redirect(url_for(".enrollment", cid=cid))
-        
+
 @admin.route("/course/<int:cid>/enrollment/batch",
              methods=['GET', 'POST'])
 @is_staff(course_arg='cid')
@@ -1449,7 +1449,7 @@ def student_view(cid, email):
             form.email.data = email
             Enrollment.enroll_from_form(cid, form)
 
-            #Modify usere's email using submitted data
+            #Modify user's email using submitted data
             user = User.lookup(email)
             user.update_email(new_email)
             flash('Edited User Successfully', 'success')

--- a/server/models.py
+++ b/server/models.py
@@ -229,6 +229,12 @@ class User(Model, UserMixin):
                                  .filter(Enrollment.role.in_(STAFF_ROLES)))
         return query.count() > 0
 
+    @transaction
+    def update_email(self, email):
+        self.email = email
+        db.session.commit()        
+        return self
+
     @staticmethod
     def get_by_id(uid):
         """ Performs .query.get; potentially can be cached."""

--- a/server/templates/staff/student/overview.html
+++ b/server/templates/staff/student/overview.html
@@ -113,7 +113,7 @@
             {% call forms.render_form(form, action_url=url_for('.student_view', cid=current_course.id, email=student.email), action_text='Submit',
             class_='form') %}
                 {{ forms.render_field(form.name, label_visible=true, placeholder='Name', required="required", type='text', value=(student.name or "")) }}
-                {{ forms.render_field(form.email, label_visible=true, required="required", value=student.email) }}
+                {{ forms.render_field(form.email, label_visible=true, required="required", value=student.email, type='email') }}
                 {{ forms.render_field(form.sid, label_visible=true, placeholder='1234567', type='text', value=(enrollment.sid or "")) }}
                 {{ forms.render_field(form.secondary, label_visible=true, placeholder='cs61a-abc', type='text', value=(enrollment.class_account or "")) }}
                 {{ forms.render_field(form.section, label_visible=true, placeholder='', type='text', value=(enrollment.section or "")) }}

--- a/server/templates/staff/student/overview.html
+++ b/server/templates/staff/student/overview.html
@@ -113,7 +113,7 @@
             {% call forms.render_form(form, action_url=url_for('.student_view', cid=current_course.id, email=student.email), action_text='Submit',
             class_='form') %}
                 {{ forms.render_field(form.name, label_visible=true, placeholder='Name', required="required", type='text', value=(student.name or "")) }}
-                {{ forms.render_field(form.email, label_visible=true, required="required", value=student.email, readonly="readonly") }}
+                {{ forms.render_field(form.email, label_visible=true, required="required", value=student.email) }}
                 {{ forms.render_field(form.sid, label_visible=true, placeholder='1234567', type='text', value=(enrollment.sid or "")) }}
                 {{ forms.render_field(form.secondary, label_visible=true, placeholder='cs61a-abc', type='text', value=(enrollment.class_account or "")) }}
                 {{ forms.render_field(form.section, label_visible=true, placeholder='', type='text', value=(enrollment.section or "")) }}


### PR DESCRIPTION
fixes #1229 

I've enabled the ability to edit emails from within the "Edit Student Form" within each course's enrollment page. Since email and name are shared between all courses (and perhaps SID should be too), this change is reflected across every single course the student is enrolled in. 