### PR TITLE
Add ability to delete backup/submissions

### DIFF
--- a/server/controllers/admin.py
+++ b/server/controllers/admin.py
@@ -184,6 +184,16 @@ def grading_view(backup, form=None, is_composition=False):
                            backup=backup, group=group, files=files, diff_type=diff_type,
                            task=task, form=form, is_composition=is_composition)
 
+@admin.route('/delete_backup/<hashid:bid>', methods=["POST"])
+@is_staff()
+def delete_backup(bid):
+    backup = Backup.query.get(bid)
+    if not backup:
+        abort(404)
+
+    db.session.delete(backup)
+    db.session.commit()
+
 @admin.route('/grading/<hashid:bid>')
 @is_staff()
 def grading(bid):

--- a/server/templates/staff/student/assignment.html
+++ b/server/templates/staff/student/assignment.html
@@ -201,7 +201,7 @@
                       <th>Submitter</th>
                       <th>ID</th>
                       <th>Scores</th>
-                      <th>Action</th>
+                      <th>Actions</th>
                       <th>Flag</th>
                     </thead>
                     <tbody>
@@ -231,6 +231,9 @@
                               <a href="{{ url_for('.grading', bid=item.id, diff='short') }}" class="btn btn-primary btn-flat">
                                   Grade
                               </a>
+                              <a href="{{ url_for('.delete_backup', bid=item.id, diff='short') }}" class="btn btn-danger btn-flat">
+                                Delete
+                            </a>
                             </div>
                             </td>
                             <td>


### PR DESCRIPTION
This adds a new "delete" button the submissions view for each student along with backend code.

Next steps are to make the button pop an alert first (to avoid accidental clicks), and to test it thoroughly, seeing as this is destructive.