### PR TITLE
Security patch for Jinja2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Flask>=0.12,<0.13,!=0.12.3 # 0.12.3 is a broken release. Ref: https://github.com/pallets/flask/issues/2728
-jinja2==2.9.6
+Jinja2==2.10.1
 
 # WSGI Containers
 gunicorn==19.7.1


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2019-10906