### PR TITLE
When editing student or staff, default to their current role, not Student

### DIFF
--- a/server/controllers/admin.py
+++ b/server/controllers/admin.py
@@ -1480,6 +1480,10 @@ def student_view(cid, email):
     if not enrollment:
         flash("This email is not enrolled", 'warning')
 
+    # Change the value in the "role" select to not default to STUDENT_ROLE
+    form.role.default = enrollment.role
+    form.process()
+
     assignments = {
         'active': [a.user_status(student, staff_view=True) for a in assignments
                    if a.active],

--- a/server/templates/staff/student/overview.html
+++ b/server/templates/staff/student/overview.html
@@ -122,9 +122,6 @@
         </div>
         <!-- /.box-body -->
         <!-- /.box-footer-->
-        <script>
-          document.getElementById("role").value = "{{ enrollment.role }}"; 
-        </script>
     </div>
     <!-- /.box -->
 

--- a/server/templates/staff/student/overview.html
+++ b/server/templates/staff/student/overview.html
@@ -122,6 +122,9 @@
         </div>
         <!-- /.box-body -->
         <!-- /.box-footer-->
+        <script>
+          document.getElementById("role").value = "{{ enrollment.role }}"; 
+        </script>
     </div>
     <!-- /.box -->
 


### PR DESCRIPTION
This resolves #1358. 

I've tried many different approaches to setting the Role select's value and nothing has worked except adding javascript. It is not ideal and I'm not proud of this PR, but it works. 