### PR TITLE
Removing `/sbin/init` from CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,6 @@ jobs:
       OK_ENV: test
     docker:
       - image: circleci/python:3.5.5-jessie-browsers
-        command: /sbin/init
       - image: redis
     steps:
       - checkout


### PR DESCRIPTION
CircleCI recently pushed a [fix](https://discuss.circleci.com/t/circleci-was-unable-to-run-the-job-runner/31894/18) for MongoDB zombie processes, by running tini as the init daemon explicitly.

Unfortunately this breaks our build when we try to run `/sbin/init`. 

The failing tests are due to #1366, for which I'm pushing a fix for shortly.
