### PR TITLE
Fix tests and bump reqs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Flask>=0.12,<0.13,!=0.12.3 # 0.12.3 is a broken release. Ref: https://github.com/pallets/flask/issues/2728
+Flask==1.1.1
 Jinja2==2.10.1
 
 # WSGI Containers
@@ -103,5 +103,5 @@ selenium==3.3.3
 # until version 1.0.6 is on pypi
 https://github.com/neta79/loremipsum/archive/py3_unicode_fix.zip
 
-# Temporary to fix #1354
-Werkzeug==0.15.3
+Werkzeug==0.15.5
+

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -165,7 +165,7 @@ class TestFile(OkTestCase):
         encoded_id = utils.encode_id(self.file2.id)
         url = "/files/{0}".format(encoded_id)
         headers, data = self.fetch_file(url)
-        self.verify_download_headers(headers, self.file2.filename, "image/svg+xml")
+        self.verify_download_headers(headers, self.file2.filename, "image/svg+xml; charset=utf-8")
         self.verify_binary_download(CWD + "/../server/static/img/logo.svg", data)
 
     def test_binary_api_download(self):
@@ -174,7 +174,7 @@ class TestFile(OkTestCase):
         url = "/api/v3/file/{0}".format(encoded_id)
         self.assertEqual(self.file2.download_link, url)
         headers, data = self.fetch_file(url)
-        self.verify_download_headers(headers, self.file2.filename, "image/svg+xml")
+        self.verify_download_headers(headers, self.file2.filename, "image/svg+xml; charset=utf-8")
         self.verify_binary_download(CWD + "/../server/static/img/logo.svg", data)
 
     def test_unauth_download(self):


### PR DESCRIPTION
Werkzeug>=0.15 doesn't support flask below 1.0. Flask-restful also started specifying the optional charset=utf-8 for `image/svg+xml` so tests were fixed. I tested manually a few common tasks and they seem to work fine.

Please merge after #1367 