### PR TITLE
Let students export their own backups

### DIFF
--- a/documentation/api.md
+++ b/documentation/api.md
@@ -383,7 +383,7 @@ A user is specified through the use of their email in Ok.
 
 #### Permissions
 The access_token's user must have permission to view the backup. They must have
-at least staff level access to the assignment.
+at least staff level access to the assignment or be the same user as the user whose backups are requested.
 
 #### HTTP Request
 `GET https://okpy.org/api/v3/assignment/<assignment_name:endpoint>/export/<string:email>`
@@ -582,7 +582,6 @@ curl "https://okpy.org/api/v3/backups/aF249e/?access_token=test"
             "download_link": "/api/v3/file/1abcdef",
             "id": "1abcdef"
         }],
-
     },
     "code": 200,
     "message": "success"

--- a/server/controllers/api.py
+++ b/server/controllers/api.py
@@ -644,7 +644,7 @@ class ExportBackup(Resource):
                 return restful.abort(404)
             return restful.abort(403)
 
-        if not self.model.can(assign, user, 'export'):
+        if user != target and not self.model.can(assign, user, 'export'):
             return restful.abort(403)
 
         base_query = (models.Backup.query.filter(


### PR DESCRIPTION
Needed for students to view their backups on code.cs61a.org. 

Blocking https://github.com/Cal-CS-61A-Staff/61a-code/pull/26