### PR TITLE
Slips Calculator Job

### DIFF
--- a/server/constants.py
+++ b/server/constants.py
@@ -21,6 +21,8 @@ SCORE_KINDS = ['composition', 'correctness', 'effort', 'total', 'partner a', 'pa
                'regrade', 'revision', 'checkpoint 1', 'checkpoint 2',
                'private', 'autograder', 'error']
 
+TIMESCALES = ['days', 'hours', 'minutes']
+
 API_PREFIX = '/api'
 OAUTH_SCOPES = ['all', 'email']
 OAUTH_OUT_OF_BAND_URI = 'urn:ietf:wg:oauth:2.0:oob'

--- a/server/controllers/admin.py
+++ b/server/controllers/admin.py
@@ -33,9 +33,8 @@ import server.canvas.jobs
 from server.extensions import cache
 import server.forms as forms
 import server.jobs as jobs
-from server.jobs import (example, export, moss, scores_audit, github_search,
-                         scores_notify, checkpoint, effort, upload_scores,
-                        export_grades)
+from server.jobs import (example, export, moss, scores_audit, github_search, scores_notify,
+                        checkpoint, effort, upload_scores, export_grades, slips)
 
 import server.highlight as highlight
 import server.utils as utils
@@ -1290,6 +1289,75 @@ def checkpoint_grading(cid, aid):
             form=form,
         )
 
+@admin.route("/course/<int:cid>/assignments/<int:aid>/slips",
+             methods=["GET", "POST"])
+@is_staff(course_arg='cid')
+def calculate_assign_slips(cid, aid):
+    courses, current_course = get_courses(cid)
+    assign = Assignment.query.filter_by(id=aid, course_id=cid).one_or_none()
+    if not assign or not Assignment.can(assign, current_user, 'grade'):
+        flash('Cannot access assignment', 'error')
+        return abort(404)
+
+    form = forms.AssignSlipCalculatorForm()
+    timescale = form.timescale.data.title()
+    if form.validate_on_submit():
+        job = jobs.enqueue_job(
+            slips.calculate_assign_slips,
+            description='Calculate Slip {} for {}'.format(timescale, assign.display_name),
+            timeout=600,
+            course_id=cid,
+            user_id=current_user.id,
+            assign_id=assign.id,
+            timescale=timescale,
+            show_results=form.show_results.data,
+            result_kind='link',
+            )
+        return redirect(url_for('.course_job', cid=cid, job_id=job.id))
+
+    return render_template(
+        'staff/jobs/slips/slips.assign.html',
+        courses=courses,
+        current_course=current_course,
+        assignment=assign,
+        form=form,
+    )
+
+@admin.route("/course/<int:cid>/assignments/slips",
+             methods=["GET", "POST"])
+@is_staff(course_arg='cid')
+def calculate_course_slips(cid):
+    courses, current_course = get_courses(cid)
+    assignments = current_course.assignments
+
+    form = forms.CourseSlipCalculatorForm()
+    inactive_assigns = [a for a in assignments if not a.active]
+    form.assigns.choices = [(a.id, a.display_name) for a in inactive_assigns]
+    form.assigns.default = [a.id for a in inactive_assigns]
+    form.process(request.form)
+    
+    timescale = form.timescale.data.title()
+    if form.validate_on_submit():
+        job = jobs.enqueue_job(
+            slips.calculate_course_slips,
+            description="Calculate Slip {} for {}'s Assignments"
+                .format(timescale, current_course.display_name),
+            timeout=600,
+            course_id=cid,
+            user_id=current_user.id,
+            timescale=timescale,
+            assigns=form.assigns.data,
+            show_results=form.show_results.data,
+            result_kind='link',
+            )
+        return redirect(url_for('.course_job', cid=cid, job_id=job.id))
+
+    return render_template(
+        'staff/jobs/slips/slips.course.html',
+        courses=courses,
+        current_course=current_course,
+        form=form,
+    )
 
 ##############
 # Enrollment #

--- a/server/forms.py
+++ b/server/forms.py
@@ -15,7 +15,7 @@ import re
 from server import utils
 import server.canvas.api as canvas_api
 from server.models import Assignment, User, Client, Course, Message, CanvasCourse
-from server.constants import (SCORE_KINDS, COURSE_ENDPOINT_FORMAT,
+from server.constants import (SCORE_KINDS, TIMESCALES, COURSE_ENDPOINT_FORMAT,
                               TIMEZONE, STUDENT_ROLE, ASSIGNMENT_ENDPOINT_FORMAT,
                               COMMON_LANGUAGES, ROLE_DISPLAY_NAMES,
                               OAUTH_OUT_OF_BAND_URI)
@@ -768,6 +768,17 @@ class EmailScoresForm(BaseForm):
 class ExportAssignment(BaseForm):
     anonymize = BooleanField('Anonymize', default=False,
                              description="Enable to remove identifying information from submissions")
+
+
+class AssignSlipCalculatorForm(BaseForm):
+    timescale = SelectField('Time Scale', default="days",
+                            choices=[(c.lower(), c.title()) for c in TIMESCALES],
+                            description="Time scale for slip calculation.")
+    show_results = BooleanField('Show Results', default=False)
+
+class CourseSlipCalculatorForm(AssignSlipCalculatorForm):
+    assigns = MultiCheckboxField('Completed Assignments ', coerce=int,
+                            description="Select which completed assignments to calculate slips for.")
 
 ##########
 # Canvas #

--- a/server/jobs/slips.py
+++ b/server/jobs/slips.py
@@ -34,7 +34,7 @@ def save_csv(csv_name, header, rows, show_results, user, course, logger):
     logger.info('Uploading...')
     upload = ExternalFile.upload(csv_iterable, 
                 user_id=user.id, course_id=course.id, name=csv_name, 
-                prefix='jobs/slips/{}'.format(course.offering))
+                prefix='slips_')
     logger.info('Saved as: {}'.format(upload.object_name))
 
     download_link = "/files/{}".format(encode_id(upload.id))
@@ -140,7 +140,7 @@ def calculate_assign_slips(assign_id, timescale, show_results):
         'User Email', 
         'Slip {} Used'.format(timescale.title()))
     rows = (get_row(subm) for subm in subms)
-    created_time = local_time(dt.now(), course, fmt='%m-%d-%I-%M-%p')
-    csv_name = '{}_{}.csv'.format(assignment.name.replace('/', '-'), created_time)
+    created_time = local_time(dt.now(), course, fmt='%m-%d_%I-%M-%p')
+    csv_name = '{}_{}.csv'.format(assignment.display_name.replace('/', '-'), created_time)
 
     return save_csv(csv_name, header, rows, show_results, user, course, logger)

--- a/server/jobs/slips.py
+++ b/server/jobs/slips.py
@@ -12,6 +12,7 @@ from server.constants import TIMESCALES
 """
  TODO: 
  - Support for timezone in filename?
+ - Remake templates as specified in the old pull request?
 """
 
 

--- a/server/jobs/slips.py
+++ b/server/jobs/slips.py
@@ -1,0 +1,106 @@
+import math
+import io
+import csv
+from collections import defaultdict
+from datetime import datetime as dt
+
+from server import jobs
+from server.models import Assignment, ExternalFile
+from server.utils import encode_id, local_time, output_csv_iterable
+from server.constants import TIMESCALES
+
+timescales = {'days':86400, 'hours':3600, 'minutes':60}
+
+def timediff(created, deadline, timescale):
+    secs_over = (created - deadline).total_seconds()
+    return math.ceil(secs_over / timescales[timescale.lower()])
+
+
+def save_csv(csv_name, header, rows, show_results, user, course, logger):
+    logger.info('Outputting csv...\n')
+    csv_iterable = output_csv_iterable(header, rows)
+
+    logger.info('Uploading...')
+    upload = ExternalFile.upload(csv_iterable, 
+                user_id=user.id, course_id=course.id, name=csv_name, 
+                prefix='jobs/slips/{}'.format(course.offering))
+    logger.info('Saved as: {}'.format(upload.object_name))
+
+    download_link = "/files/{}".format(encode_id(upload.id))
+    logger.info('Download link: {} (see "result" above)\n'.format(download_link))
+
+    if show_results:
+        logger.info('Results:\n')
+        csv_data = ''.join([row.decode('utf-8') for row in csv_iterable])
+        logger.info(csv_data)
+
+    return download_link
+
+
+@jobs.background_job
+def calculate_course_slips(assigns, timescale, show_results):
+    logger = jobs.get_job_logger()
+    logger.info('Calculating Slip {}...\n'.format(timescale.title()))
+
+    job = jobs.get_current_job()
+    user = job.user
+    course = job.course
+    assigns_set = set(assigns)
+    assigns = (a for a in course.assignments if a.id in assigns_set)
+
+    course_slips = defaultdict(list)
+    for i, assign in enumerate(assigns, 1):
+        logger.info('Processing {} ({} of {})...'
+            .format(assign.display_name, i, len(assigns_set)))
+        subms = assign.course_submissions(include_empty=False)
+        deadline = assign.due_date
+        assign_slips = {}
+        for subm in subms:
+            email = subm['user']['email']
+            created = subm['backup']['created']
+            slips = max(0, timediff(created, deadline, timescale))
+            assign_slips[email] = [(assign.display_name, slips)]
+        course_slips = {k:course_slips[k] + assign_slips[k] 
+                        for k in course_slips.keys() | assign_slips.keys()}
+
+    def get_row(email, assign_slips):
+        total_slips = sum((s for a, s in assign_slips))
+        assignments = ', '.join([a for a, s in assign_slips if s > 0])
+        return (email, total_slips, assignments)
+    
+    header = (
+        'User Email', 
+        'Slip {} Used'.format(timescale.title()),
+        'Late Assignments')
+    rows = (get_row(*user_slips) for user_slips in course_slips.items())
+    created_time = local_time(dt.now(), course, fmt='%m-%d-%I-%M-%p')
+    csv_name = '{}_{}.csv'.format(course.offering.replace('/', '-'), created_time)
+
+    return save_csv(csv_name, header, rows, show_results, user, course, logger)
+
+
+@jobs.background_job
+def calculate_assign_slips(assign_id, timescale, show_results):
+    logger = jobs.get_job_logger()
+    logger.info('Calculating Slip {}...'.format(timescale.title()))
+    
+    user = jobs.get_current_job().user
+    assignment = Assignment.query.get(assign_id)
+    course = assignment.course
+    subms = assignment.course_submissions(include_empty=False)
+    deadline = assignment.due_date
+
+    def get_row(subm):
+        email = subm['user']['email']
+        created = subm['backup']['created']
+        slips = max(0, timediff(created, deadline, timescale))
+        return (email, slips)
+
+    header = (
+        'User Email', 
+        'Slip {} Used'.format(timescale.title()))
+    rows = (get_row(subm) for subm in subms)
+    created_time = local_time(dt.now(), course, fmt='%m-%d-%I-%M-%p')
+    csv_name = '{}_{}.csv'.format(assignment.name.replace('/', '-'), created_time)
+
+    return save_csv(csv_name, header, rows, show_results, user, course, logger)

--- a/server/jobs/slips.py
+++ b/server/jobs/slips.py
@@ -49,6 +49,14 @@ def save_csv(csv_name, header, rows, show_results, user, course, logger):
 
     return download_link
 
+"""
+Of how many submissions is the user's score comprised?
+Which submissions do we consider relevant? How many relevant submissions can there be?
+Would a pair of final submission and revision backup be sufficient?
+"""
+def return_relevant_submissions(assignment, user):
+    pass
+
 
 @jobs.background_job
 def calculate_course_slips(assigns, timescale, show_results):

--- a/server/jobs/slips.py
+++ b/server/jobs/slips.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from datetime import datetime as dt
 
 from server import jobs
-from server.models import Assignment, ExternalFile
+from server.models import Assignment, ExternalFile, User
 from server.utils import encode_id, local_time, output_csv_iterable
 from server.constants import TIMESCALES
 
@@ -17,7 +17,7 @@ from server.constants import TIMESCALES
  - Calculate slip days separately for each relevant submission
  - Remove the "show results" button
  "show results" displays the table in the logger. Should we keep it?
- - Show SID in addition to the email
+ - Show SID in addition to the email (NOT THE ID!)
  - Work around output_csv_iterable
 """
 
@@ -53,6 +53,10 @@ def save_csv(csv_name, header, rows, show_results, user, course, logger):
 Of how many submissions is the user's score comprised?
 Which submissions do we consider relevant? How many relevant submissions can there be?
 Would a pair of final submission and revision backup be sufficient?
+
+Points, Style points, Check points
+Points -> give best submission for effort, total and regrade
+
 """
 def return_relevant_submissions(assignment, user):
     pass
@@ -115,7 +119,10 @@ def calculate_assign_slips(assign_id, timescale, show_results):
     deadline = assignment.due_date
 
     def get_row(subm):
-        sid = subm['user']['id']
+        user_id = subm['user']['id']
+        user = User.get_by_id(user_id)
+        enrollment = user.enrollments()[0]
+        sid = enrollment.sid
         email = subm['user']['email']
         created = subm['backup']['created']
         slips = max(0, timediff(created, deadline, timescale))

--- a/server/jobs/slips.py
+++ b/server/jobs/slips.py
@@ -56,8 +56,6 @@ Points, Style points, Check points
 Points -> give best submission for effort, total and regrade
 
 """
-def return_relevant_submissions(assignment, user):
-    pass
 
 
 @jobs.background_job

--- a/server/jobs/slips.py
+++ b/server/jobs/slips.py
@@ -16,6 +16,7 @@ from server.constants import TIMESCALES
  - Restrict calculation of slip days to only one assignment (weird otherwise)
  - Calculate slip days separately for each relevant submission
  - Remove the "show results" button
+ "show results" displays the table in the logger. Should we keep it?
  - Show SID in addition to the email
  - Work around output_csv_iterable
 """
@@ -90,7 +91,10 @@ def calculate_course_slips(assigns, timescale, show_results):
 
     return save_csv(csv_name, header, rows, show_results, user, course, logger)
 
-
+"""
+Changed this method so that it also returns the user's id.
+Is subm['user']['id'] the same as SID?
+"""
 @jobs.background_job
 def calculate_assign_slips(assign_id, timescale, show_results):
     logger = jobs.get_job_logger()
@@ -103,12 +107,14 @@ def calculate_assign_slips(assign_id, timescale, show_results):
     deadline = assignment.due_date
 
     def get_row(subm):
+        sid = subm['user']['id']
         email = subm['user']['email']
         created = subm['backup']['created']
         slips = max(0, timediff(created, deadline, timescale))
-        return (email, slips)
+        return sid, email, slips
 
     header = (
+        'User SID',
         'User Email', 
         'Slip {} Used'.format(timescale.title()))
     rows = (get_row(subm) for subm in subms)

--- a/server/jobs/slips.py
+++ b/server/jobs/slips.py
@@ -9,6 +9,18 @@ from server.models import Assignment, ExternalFile
 from server.utils import encode_id, local_time, output_csv_iterable
 from server.constants import TIMESCALES
 
+"""
+ TODO: 
+ - Use TIMESCALES instead of timescales
+ - Look through the code and search for optimizations
+ - Restrict calculation of slip days to only one assignment (weird otherwise)
+ - Calculate slip days separately for each relevant submission
+ - Remove the "show results" button
+ - Show SID in addition to the email
+ - Work around output_csv_iterable
+"""
+
+
 timescales = {'days':86400, 'hours':3600, 'minutes':60}
 
 def timediff(created, deadline, timescale):

--- a/server/jobs/slips.py
+++ b/server/jobs/slips.py
@@ -69,7 +69,11 @@ def calculate_course_slips(assigns, timescale, show_results):
         logger.info('Processing {} ({} of {})...'
                     .format(assign.display_name, i, len(assigns_set)))
         students_ids = get_students_with_submission(assign)
-        subms = [assign.final_submission([id]) for id in students_ids]
+        subms = []
+        for id in students_ids:
+            subm = assign.final_submission([id])
+            if subm:
+                subms.append(subm)
         deadline = assign.due_date
         for subm in subms:
             curr_user = subm.submitter
@@ -78,7 +82,6 @@ def calculate_course_slips(assigns, timescale, show_results):
             email = curr_user.email
             created = subm.submission_time
             slips = max(0, timediff(created, deadline, timescale))
-            logger.info('LOG: ' + email + ' ' + str(slips))
             if slips > 0:
                 rows.append([assign.display_name, sid, email, slips])
 
@@ -116,10 +119,13 @@ def calculate_assign_slips(assign_id, timescale, show_results):
     assignment = Assignment.query.get(assign_id)
     course = assignment.course
     students_ids = get_students_with_submission(assignment)
-    subms = [assignment.final_submission([id]) for id in students_ids]
+    subms = []
+    for id in students_ids:
+        subm = assignment.final_submission([id])
+        if subm:
+            subms.append(subm)
     deadline = assignment.due_date
     rows = []
-
     for subm in subms:
         curr_user = subm.submitter
         enrollment = curr_user.enrollments()[0]

--- a/server/templates/staff/course/assignment/assignment.html
+++ b/server/templates/staff/course/assignment/assignment.html
@@ -96,7 +96,11 @@
                         <i class="fa fa-thumbs-up"></i> Effort Grading
                   </a></li>
                   <li> <a href="{{ autograder_url }}" target="_blank" type="button">
-                        <i class="fa fa-gear"></i> Configure Autograder
+                      <i class="fa fa-gear"></i> Configure Autograder
+                  </a></li>
+
+                  <li> <a href="{{ url_for('.calculate_assign_slips', cid=current_course.id, aid=assignment.id) }}" type="button">
+                        <i class="fa fa-calculator"></i> Calculate Slips
                   </a></li>
                   <li>
                     {% call forms.render_form_bare(CSRFForm(), action_url=url_for('.autograde', cid=current_course.id, aid=assignment.id), class_='form') %}

--- a/server/templates/staff/course/assignment/assignments.html
+++ b/server/templates/staff/course/assignment/assignments.html
@@ -20,6 +20,25 @@
         {% include 'alerts.html' %}
 
         <!-- Default box -->
+        <div class="box box-solid">
+          <div class="box-header with-border">
+            <h3 class="box-title">Actions</h3>
+            <div class="box-tools pull-right">
+              <button type="button" class="btn btn-box-tool" data-widget="collapse" data-toggle="tooltip" title="" data-original-title="Collapse">
+                <i class="fa fa-minus"></i></button>  
+            </div>
+          </div>
+          <div class="box-body">
+            <ul class="nav nav-pills">
+              <li> <a href="{{url_for('.calculate_course_slips', cid=current_course.id)}}" type="button">
+                    <i class="fa fa-calculator"></i> Calculate Slips
+              </a></li>
+            </ul>
+          </div>
+          <!-- /.box-body -->
+        </div>
+
+        <!-- Default box -->
         <div class="box">
           <div class="box-header with-border">
             <h3 class="box-title">Active Assignments</h3>
@@ -66,9 +85,8 @@
         <div class="box">
           <div class="box-header with-border">
             <h3 class="box-title">Completed Assignments</h3>
-
             <div class="box-tools pull-right">
-              <button type="button" class="btn btn-box-tool" data-widget="collapse" data-toggle="tooltip" title="Collapse">
+              <button type="button" class="btn btn-box-tool" data-widget="collapse" data-toggle="tooltip" title="" data-original-title="Collapse">
                 <i class="fa fa-minus"></i></button>
             </div>
           </div>

--- a/server/templates/staff/jobs/slips/slips.assign.html
+++ b/server/templates/staff/jobs/slips/slips.assign.html
@@ -1,0 +1,44 @@
+{% extends "staff/base.html" %}
+{% import "staff/_formhelpers.html" as forms %}
+
+{% block title %} Calculate Slips for {{ assignment.display_name }} {% endblock %}
+
+{% block main %}
+<section class="content-header">
+    <h1>
+        Calculate Slips for {{ assignment.display_name }}
+        <small>{{ current_course.offering }}</small>
+    </h1>
+    <ol class="breadcrumb">
+        <li><a href="{{ url_for(".course", cid=current_course.id) }}">
+            <i class="fa fa-university"></i> {{ current_course.offering }}
+        </a></li>
+        <li><a href="{{ url_for('.course_assignments', cid=current_course.id) }}">
+          <i class="fa fa-list"></i> Assignments</a>
+        </li>
+        <li> <a href="{{ url_for('.assignment', cid=current_course.id, aid=assignment.id) }}"><i class="fa fa-book"></i> {{ assignment.display_name }} </a></li>
+        <li><a href="{{ url_for(".course_jobs", cid=current_course.id) }}">
+            <i class="fa fa-list"></i>Jobs
+        </a></li>
+        <li class="active"><a href="#">
+            <i class="fa fa-inbox"></i>Calculate Slips</a>
+        </li>
+    </ol>
+</section>
+<section class="content">
+  {% include 'alerts.html' %}
+  <div class="row">
+    <div class="col-md-12">
+      <div class="box">
+        <div class="box-body">
+          <p> Calculate slips and save as a .csv file. </p>
+          {% call forms.render_form(form, action_text='Calculate Slips') %}
+            {{ forms.render_field(form.timescale) }}
+            {{ forms.render_checkbox_field(form.show_results) }}
+          {% endcall %}
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+{% endblock %}

--- a/server/templates/staff/jobs/slips/slips.course.html
+++ b/server/templates/staff/jobs/slips/slips.course.html
@@ -1,0 +1,44 @@
+{% extends "staff/base.html" %}
+{% import "staff/_formhelpers.html" as forms %}
+
+{% block title %} Calculate Slips for {{ current_course.display_name }} {% endblock %}
+
+{% block main %}
+<section class="content-header">
+    <h1>
+        Calculate Slips for {{ current_course.display_name }}
+        <small>{{ current_course.offering }}</small>
+    </h1>
+    <ol class="breadcrumb">
+        <li><a href="{{ url_for(".course", cid=current_course.id) }}">
+            <i class="fa fa-university"></i> {{ current_course.offering }}
+        </a></li>
+        <li><a href="{{ url_for('.course_assignments', cid=current_course.id) }}">
+          <i class="fa fa-list"></i> Assignments</a>
+        </li>
+        <li><a href="{{ url_for(".course_jobs", cid=current_course.id) }}">
+            <i class="fa fa-list"></i>Jobs
+        </a></li>
+        <li class="active"><a href="#">
+            <i class="fa fa-inbox"></i>Calculate Slips</a>
+        </li>
+    </ol>
+</section>
+<section class="content">
+  {% include 'alerts.html' %}
+  <div class="row">
+    <div class="col-md-12">
+      <div class="box">
+        <div class="box-body">
+          <p> Calculate slips and save as a .csv file. </p>
+          {% call forms.render_form(form, action_text='Calculate Slips') %}
+            {{ forms.render_field(form.timescale) }}
+            {{ forms.render_checkbox_field(form.assigns) }}
+            {{ forms.render_checkbox_field(form.show_results) }}
+          {% endcall %}
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+{% endblock %}

--- a/server/utils.py
+++ b/server/utils.py
@@ -256,17 +256,6 @@ def chunks(l, n):
         yield l[prev_index:index]
         prev_index = index
 
-
-def output_csv_iterable(header, rows):
-    """ Generate csv string for given header list and list of rows (lists). """
-    output = StringIO()
-    writer = csv.writer(output, quoting=csv.QUOTE_NONNUMERIC)
-    writer.writerow(header)
-    [writer.writerow(row) for row in rows]
-    rows = output.getvalue().split('\r\n')
-    return [bytes(row + '\r\n', 'utf-8') for row in rows]
-
-
 def generate_csv(query, items, selector_fn):
     """ Generate csv export of scores for assignment.
         selector_fn: 1 arg function that returns a list of dictionaries

--- a/server/utils.py
+++ b/server/utils.py
@@ -257,6 +257,16 @@ def chunks(l, n):
         prev_index = index
 
 
+def output_csv_iterable(header, rows):
+    """ Generate csv string for given header list and list of rows (lists). """
+    output = StringIO()
+    writer = csv.writer(output, quoting=csv.QUOTE_NONNUMERIC)
+    writer.writerow(header)
+    [writer.writerow(row) for row in rows]
+    rows = output.getvalue().split('\r\n')
+    return [bytes(row + '\r\n', 'utf-8') for row in rows]
+
+
 def generate_csv(query, items, selector_fn):
     """ Generate csv export of scores for assignment.
         selector_fn: 1 arg function that returns a list of dictionaries


### PR DESCRIPTION
This pull request is supposed to solve the problem addressed in #1375 

This is an updated version of #1068 which takes into account most of the comments for that PR. The main changed made is that in the initial PR slips were calculated for each of user's submissions and in this PR they are calculated only for the final submission.

Slips can be calculated both for the whole course (with an option to change which exact assignments should be included) and for individual assignments.

![Calculating for the whole course](https://user-images.githubusercontent.com/24683367/75926466-72b9d580-5e1f-11ea-802e-0d624068bbfe.png)

![Calculating slips for an assignment](https://user-images.githubusercontent.com/24683367/75926238-1060d500-5e1f-11ea-8f77-cec66211681a.png)

Output of the job is an .csv table which contains and SID, email and the amoung of slip days (or hours, minutes) used by a student. If a student has not used slip days, they will not be included in the table.

![Calculating slips log](https://user-images.githubusercontent.com/24683367/75926352-40a87380-5e1f-11ea-8d3b-d41debe49946.png)

![Output csv for a specific assignment](https://user-images.githubusercontent.com/24683367/75926381-4f8f2600-5e1f-11ea-948b-aa8d35c96da2.png)


