### PR TITLE
update requirements.txt and Dockerfile for successful build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.5-alpine
+FROM python:3.8-alpine
 
 RUN apk add --update \
     supervisor \
@@ -23,6 +23,8 @@ RUN ln -sf /dev/stdout /var/log/nginx/access.log && \
     ln -sf /dev/stderr /var/log/nginx/error.log
 
 ADD . .
+
+RUN mkdir /etc/nginx/conf.d
 
 RUN mv docker/nginx/nginx.conf /etc/nginx/nginx.conf && \
     mv docker/nginx/default.conf /etc/nginx/conf.d/default.conf && \

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,8 @@ raven[flask]==6.0.0
 
 # Database
 pymysql==0.8.0
-SQLAlchemy>=1.3.0
+SQLAlchemy<1.4.0
+markupsafe==2.0.1
 
 # Caching
 redis==2.10.5
@@ -76,7 +77,7 @@ idna<2.9,>=2.5
 # Front end
 itsdangerous==0.24
 cssmin==0.2.0
-jsmin==2.2.1
+jsmin==3.0.1
 hashids==1.2.0
 pygments==2.2.0
 humanize==0.5.1


### PR DESCRIPTION
With higher version of virtualenv installed, attempting the installation of jsmin==2.2.1 yields error, therefore, updated to 3.0.1.

Once updated, in order to make manage.py runs properly, markupsafe and sqlalchemy version are also needed to be updated.

Once applied changes on requirements.txt, the Dockerfile with python image version of 3.5 could not be built successfully, therefore update the image version up to 3.8-alpine.