### PR TITLE
Upgrade Python->3.5, Gunicorn->19.9.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
       CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
       OK_ENV: test
     docker:
-      - image: circleci/python:3.5.5-jessie-browsers
+      - image: circleci/python:3.7
       - image: redis
     steps:
       - checkout

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.5-alpine
+FROM python:3.7-alpine
 
 RUN apk add --update \
     supervisor \

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ raven[flask]==6.0.0
 
 # Database
 pymysql==0.8.0
-SQLAlchemy>=1.3.0
+SQLAlchemy==2.0
 
 # Caching
 redis==2.10.5
@@ -55,9 +55,7 @@ Flask-RQ==0.2
 pyjwt==1.6.1
 
 # Flask DB Extensions
-Flask-SQLAlchemy==2.2
-# Fork of Flask-SQLAlchemy==2.2 that supports custom create_engine paramters - use until https://github.com/mitsuhiko/flask-sqlalchemy/issues/166 is resolved
-# https://github.com/c-w/flask-sqlalchemy/archive/2.2-with-engine-params-fix.zip
+Flask-SQLAlchemy==3.0
 Flask-SQLAlchemy-Cache==0.1.5
 Flask-Migrate==2.0.3
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -110,3 +110,6 @@ selenium==3.3.3
 https://github.com/neta79/loremipsum/archive/py3_unicode_fix.zip
 
 Werkzeug==0.14.1
+
+# ensure compatibility
+MarkupSafe==2.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ raven[flask]==6.0.0
 
 # Database
 pymysql==0.8.0
-SQLAlchemy>=1.3.0,<2.0
+SQLAlchemy==1.3.0
 
 # Caching
 redis==2.10.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -76,7 +76,7 @@ idna<2.9,>=2.5
 # Front end
 itsdangerous==0.24
 cssmin==0.2.0
-jsmin==2.2.1
+jsmin==3.0.1
 hashids==1.2.0
 pygments==2.2.0
 humanize==0.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ Flask==1.0.4
 Jinja2==2.10.1
 
 # WSGI Containers
-gunicorn==19.7.1
+gunicorn==19.9.0
 envdir==1.0.1
 
 # Errors

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ raven[flask]==6.0.0
 
 # Database
 pymysql==0.8.0
-SQLAlchemy==2.0
+SQLAlchemy>=1.3.0,<2.0
 
 # Caching
 redis==2.10.5
@@ -55,7 +55,9 @@ Flask-RQ==0.2
 pyjwt==1.6.1
 
 # Flask DB Extensions
-Flask-SQLAlchemy==3.0
+Flask-SQLAlchemy==2.2
+# Fork of Flask-SQLAlchemy==2.2 that supports custom create_engine paramters - use until https://github.com/mitsuhiko/flask-sqlalchemy/issues/166 is resolved
+# https://github.com/c-w/flask-sqlalchemy/archive/2.2-with-engine-params-fix.zip
 Flask-SQLAlchemy-Cache==0.1.5
 Flask-Migrate==2.0.3
 


### PR DESCRIPTION
okpy.org has been down since 5/2/25. This is a potential fix.

CS 61A infra team will retroactively document the root cause once we find the fix.